### PR TITLE
Chat, CE-RCON, CobaltConfigMngr fixes

### DIFF
--- a/CE-RCON.lua
+++ b/CE-RCON.lua
@@ -30,7 +30,7 @@ function startRCON(port)
 	MP.RegisterEvent("RCONreply","RCONreply")
 	MP.RegisterEvent("listenRCON","listenRCON")
 
-	MP.CreateEventTimer("listenRCON", 100)
+	MP.CreateEventTimer("listenRCON", 200)
 
 	CElog("RCON open on port " .. port,"RCON")
 

--- a/lua/CobaltConfigMngr.lua
+++ b/lua/CobaltConfigMngr.lua
@@ -30,19 +30,19 @@ local beamMPconfigMetatable = {
 	end,
 	__newindex = function(table, key, value)
 		if key == "Debug" then
-			Set(0, value)
+			MP.Set(0, value)
 		elseif key == "Private" then
-			Set(1, value)
+			MP.Set(1, value)
 		elseif key == "MaxCars" then
-			Set(2, value)
+			MP.Set(2, value)
 		elseif key == "MaxPlayers" then
-			Set(3, value)
+			MP.Set(3, value)
 		elseif key == "Map" then
-			Set(4, value)
+			MP.Set(4, value)
 		elseif key == "Name" then 
-			Set(5, value)
+			MP.Set(5, value)
 		elseif key == "Description" then
-			Set(6, value)
+			MP.Set(6, value)
 		else
 			return nil
 		end

--- a/lua/CobaltEssentials.lua
+++ b/lua/CobaltEssentials.lua
@@ -168,7 +168,6 @@ end
 
 
 function onChatMessage(playerID, name ,chatMessage)
-	chatMessage = chatMessage:sub(2)
 
 	if extensions.triggerEvent("onChatMessage", players[playerID], chatMessage) == false then
 		return -1


### PR DESCRIPTION
BeamMP Server 3.0.0 fixes chat messages trailing whitespace so we no longer need to compensate for this here.