### PR TITLE
Cleanup language and formatting

### DIFF
--- a/CobaltDB.lua
+++ b/CobaltDB.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --COBALTESSENTIALS IS PROTECTED UNDER AN GPLv3 LICENSE
 
 --    PRE: Precondition

--- a/CobaltEssentialsLoader.lua
+++ b/CobaltEssentialsLoader.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --COBALTESSENTIALS IS PROTECTED UNDER AN GPLv3 LICENSE
 
 MP.RegisterEvent("onCobaltDBhandshake","onCobaltDBhandshake") --to make sure cobaltDB loads first

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # CobaltEssentials
-CobaltEssentials for beamMP
+CobaltEssentials for BeamMP
 
 Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # CobaltEssentials
 CobaltEssentials for BeamMP
 
-Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED

--- a/lua/CobaltCommands.lua
+++ b/lua/CobaltCommands.lua
@@ -338,7 +338,7 @@ end
 
 local function testCommand(sender, ...)
 	CElog("Test Command Executed")
-	return "Test Sucessful"
+	return "Test successful"
 end
 
 local function say(sender, message, ...)

--- a/lua/CobaltCommands.lua
+++ b/lua/CobaltCommands.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --COBALTESSENTIALS IS PROTECTED UNDER AN GPLv3 LICENSE
 
 local M = {}

--- a/lua/CobaltCompat.lua
+++ b/lua/CobaltCompat.lua
@@ -111,7 +111,7 @@ local function registerCommand(command, func, reqPerm, desc, argCount, RCONonly)
 	commands[command].arguments = argCount
 	commands[command].description = desc
 
-	commands[command].orginModule = "CC"
+	commands[command].originModule = "CC"
 
 	if RCONonly == 1 then
 		commands[command].sourceLimited = 2

--- a/lua/CobaltCompat.lua
+++ b/lua/CobaltCompat.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --COBALTESSENTIALS IS PROTECTED UNDER AN GPLv3 LICENSE
 
 --    PRE: Precondition

--- a/lua/CobaltConfigMngr.lua
+++ b/lua/CobaltConfigMngr.lua
@@ -78,12 +78,12 @@ local defaultConfig =
 {
 	commandPrefix =		{value = "/",			description = "The character placed at the beginning of a chat message when using a command"},
 	consolePrefix =		{value = "ce ",			description = "The text placed at the beginning of a console command"},
-	maxActivePlayers =	{value = 20,			description = "max amount of active/nonspectator players allowed on a server, any further players will be spectator and placed on a queue."},
-	enableWhitelist =	{value = false,			description = "weather or not the whitelist is enabled"},
-	enableDebug =		{value = false,			description = "weather or not the server will output debug messages."},
-	enableColors =		{value = true,			description = "weather or not console outputs can utilize colors. Causes problems with environments missing ANSI escape sequence support. Requires Restart"},
+	maxActivePlayers =	{value = 20,			description = "max amount of active/nonspectator players allowed on a server, any further players will be spectator and placed in a queue"},
+	enableWhitelist =	{value = false,			description = "whether or not the whitelist is enabled"},
+	enableDebug =		{value = false,			description = "whether or not the server will output debug messages"},
+	enableColors =		{value = true,			description = "whether or not console outputs can utilize colors. Causes problems with environments missing ANSI escape sequence support. Requires restart"},
 
-	RCONenabled =		{value = true,			description = "weather or not the server runs a q3 compliant rcon server for remote acess to the server. Requires Restart"},
+	RCONenabled =		{value = true,			description = "whether or not the server runs a q3 compliant rcon server for remote access to the server. Requires restart"},
 	RCONport =			{value = 20814,			description = "The port used to host the server. Since CE is external to beamMP make sure to not place this on the same port as the server."},
 	RCONpassword =		{value = "password",	description = "The password required to connect to the RCON"},
 	RCONkeepAliveTick = {value = false,			description = "The amount of seconds between ticks sent to RCONclients to keep the connections alive, false to disable, This may not work?"},
@@ -95,8 +95,8 @@ local defaultPermissions =
 {
 	--note: the numbers are displayed as strings because they must be, when referenced, everything will be converted to numbers appropriately.
 	spawnVehicles =	{[0] = true, description = "If you may spawn vehicles or not."},
-	sendMessage =	{[0]  = true, description = "If send messages in chat or not."},
-	vehicleCap =	{[1] = 1, [3] = 2, [5] = 5, [10] = 10, description = "The  amount of vehicles that may be spawned based on permission level."}
+	sendMessage =	{[0]  = true, description = "If you may send messages in chat or not."},
+	vehicleCap =	{[1] = 1, [3] = 2, [5] = 5, [10] = 10, description = "The amount of vehicles that may be spawned based on permission level."}
 }
 
 local defaultCommands =
@@ -107,22 +107,22 @@ local defaultCommands =
 	help =			{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = {"*command"},			description = "Lists all commands accessible by the player"},
 	status =		{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Lists all the players on the server with their ids and basic information on the server"},
 	statusdetail =	{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Lists all the players on the server in detail along with basic server information"},
-	connected =		{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Get the connect stage of all players on the server"},
-	about =			{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Displays the license, version, and copyright notice assosiated with Cobalt Essentials."},
+	connected =		{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Get the connection state of all players on the server"},
+	about =			{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Displays the license, version, and copyright notice associated with Cobalt Essentials"},
 	uptime =		{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Get the uptime of the server"},
 	countdown =		{orginModule = "CC",	level = 1,	sourceLimited = 0,	arguments = 0,						description = "Start a countdown in chat"},
 	whitelist =		{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"subcommand"},			description = "Control the server's whitelist"},
-	say =			{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"message"},			description = "Say a message as the server."},
+	say =			{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"message"},			description = "Say a message as the server"},
 	mute =			{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"player","*reason"},	description = "Disallow a player from talking"},
 	unmute =		{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"player"},				description = "Allow a muted player to talk again"},
 	kick =			{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"player","*reason"},	description = "Kick a player from the session"},
-	setcfg =		{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"option","value"},		description = "Set a vanilla beamMP server config option."},
+	setcfg =		{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"option","value"},		description = "Set a vanilla beamMP server config option"},
 	ban =			{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player","*reason"},	description = "Ban a player from the server"},
 	unban =			{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player"},				description = "Unban a player from the server"},
-	setperm =		{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player","value"},		description = "Change a player's permission level"},
+	setperm =		{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player","value"},		description = "Set a player's permission level"},
 	setgroup =		{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player","value"},		description = "Set a player's permission group"},
-	lua =			{orginModule = "CC",	level = 10,	sourceLimited = 2,	arguments = {"command"},			description = "Execute Lua, return the desired reply."},
-	reload =		{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"extension"},			description = "Reloads the given Cobalt Extenion"},
+	lua =			{orginModule = "CC",	level = 10,	sourceLimited = 2,	arguments = {"command"},			description = "Execute Lua, return the desired reply"},
+	reload =		{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"extension"},			description = "Reload the given Cobalt Extension"},
 	togglechat =	{orginModule = "CC",	level =	10,	sourceLimited = 2,	arguments = 0,						description = "Toggles viewing chat in the RCON client"},
 	stop =			{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = 0,						description = "Stops the server"}
 }

--- a/lua/CobaltConfigMngr.lua
+++ b/lua/CobaltConfigMngr.lua
@@ -101,30 +101,30 @@ local defaultPermissions =
 
 local defaultCommands =
 {
-	--orginModule[commandName] is where the command is executed from
+	--originModule[commandName] is where the command is executed from
 	--Source-Limit-Map [0:no limit | 1:Chat Only | 2:RCON Only]
 	--A star before an argument actually means the opposite of what it would traditionally mean, a '*' means the argument is optional.
-	help =			{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = {"*command"},			description = "Lists all commands accessible by the player"},
-	status =		{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Lists all the players on the server with their ids and basic information on the server"},
-	statusdetail =	{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Lists all the players on the server in detail along with basic server information"},
-	connected =		{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Get the connection state of all players on the server"},
-	about =			{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Displays the license, version, and copyright notice associated with Cobalt Essentials"},
-	uptime =		{orginModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Get the uptime of the server"},
-	countdown =		{orginModule = "CC",	level = 1,	sourceLimited = 0,	arguments = 0,						description = "Start a countdown in chat"},
-	whitelist =		{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"subcommand"},			description = "Control the server's whitelist"},
-	say =			{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"message"},			description = "Say a message as the server"},
-	mute =			{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"player","*reason"},	description = "Disallow a player from talking"},
-	unmute =		{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"player"},				description = "Allow a muted player to talk again"},
-	kick =			{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"player","*reason"},	description = "Kick a player from the session"},
-	setcfg =		{orginModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"option","value"},		description = "Set a vanilla beamMP server config option"},
-	ban =			{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player","*reason"},	description = "Ban a player from the server"},
-	unban =			{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player"},				description = "Unban a player from the server"},
-	setperm =		{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player","value"},		description = "Set a player's permission level"},
-	setgroup =		{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player","value"},		description = "Set a player's permission group"},
-	lua =			{orginModule = "CC",	level = 10,	sourceLimited = 2,	arguments = {"command"},			description = "Execute Lua, return the desired reply"},
-	reload =		{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"extension"},			description = "Reload the given Cobalt Extension"},
-	togglechat =	{orginModule = "CC",	level =	10,	sourceLimited = 2,	arguments = 0,						description = "Toggles viewing chat in the RCON client"},
-	stop =			{orginModule = "CC",	level = 10,	sourceLimited = 0,	arguments = 0,						description = "Stops the server"}
+	help =			{originModule = "CC",	level = 0,	sourceLimited = 0,	arguments = {"*command"},			description = "Lists all commands accessible by the player"},
+	status =		{originModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Lists all the players on the server with their ids and basic information on the server"},
+	statusdetail =	{originModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Lists all the players on the server in detail along with basic server information"},
+	connected =		{originModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Get the connection state of all players on the server"},
+	about =			{originModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Displays the license, version, and copyright notice associated with Cobalt Essentials"},
+	uptime =		{originModule = "CC",	level = 0,	sourceLimited = 0,	arguments = 0,						description = "Get the uptime of the server"},
+	countdown =		{originModule = "CC",	level = 1,	sourceLimited = 0,	arguments = 0,						description = "Start a countdown in chat"},
+	whitelist =		{originModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"subcommand"},			description = "Control the server's whitelist"},
+	say =			{originModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"message"},			description = "Say a message as the server"},
+	mute =			{originModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"player","*reason"},	description = "Disallow a player from talking"},
+	unmute =		{originModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"player"},				description = "Allow a muted player to talk again"},
+	kick =			{originModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"player","*reason"},	description = "Kick a player from the session"},
+	setcfg =		{originModule = "CC",	level = 5,	sourceLimited = 0,	arguments = {"option","value"},		description = "Set a vanilla beamMP server config option"},
+	ban =			{originModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player","*reason"},	description = "Ban a player from the server"},
+	unban =			{originModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player"},				description = "Unban a player from the server"},
+	setperm =		{originModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player","value"},		description = "Set a player's permission level"},
+	setgroup =		{originModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"player","value"},		description = "Set a player's permission group"},
+	lua =			{originModule = "CC",	level = 10,	sourceLimited = 2,	arguments = {"command"},			description = "Execute Lua, return the desired reply"},
+	reload =		{originModule = "CC",	level = 10,	sourceLimited = 0,	arguments = {"extension"},			description = "Reload the given Cobalt Extension"},
+	togglechat =	{originModule = "CC",	level =	10,	sourceLimited = 2,	arguments = 0,						description = "Toggles viewing chat in the RCON client"},
+	stop =			{originModule = "CC",	level = 10,	sourceLimited = 0,	arguments = 0,						description = "Stops the server"}
 }
 
 local defaultVehiclePermissions =

--- a/lua/CobaltConfigMngr.lua
+++ b/lua/CobaltConfigMngr.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --COBALTESSENTIALS IS PROTECTED UNDER AN GPLv3 LICENSE
 
 --    PRE: Precondition

--- a/lua/CobaltDBconnector.lua
+++ b/lua/CobaltDBconnector.lua
@@ -117,9 +117,9 @@ local function newDatabase(DBname)
 	if databaseLoaderInfo ~= nil then
 		if databaseLoaderInfo:sub(1,2) == "E:" then
 			CElog(DBname .. " could not be opened after 5 tries due to: " .. databaseLoaderInfo:sub(3),"CobaltDB")
-			return nil, "CobaltDB failed to load " .. DBname .. "after 5 tries due to : " .. databaseLoaderInfo:sub(3)
+			return nil, "CobaltDB failed to load " .. DBname .. "after 5 tries due to: " .. databaseLoaderInfo:sub(3)
 		else
-			CElog(DBname .. " sucessfully opened.","CobaltDB")
+			CElog(DBname .. " successfully opened.","CobaltDB")
 
 			newDatabase =
 			{
@@ -299,7 +299,7 @@ local function openDatabase(DBname)
 
 	MP.TriggerLocalEvent("openDatabase", DBname)
 	if M.receiveDB(requestID) == DBname then
-		--CElog(DBname .. " sucessfully opened.","CobaltDB")
+		--CElog(DBname .. " successfully opened.","CobaltDB")
 
 		--server:close()
 		return true
@@ -332,13 +332,13 @@ local function repairCobaltDBconnection(reason)
 	local recTime = os.clock() * 1000
 
 	if data == port then
-		CElog(color(32) .. "CobaltDB Connection sucessfully repaired with a propagation delay of " .. math.floor(recTime - startTime) .. "ms","WARN")
-		--CElog(color(32) .. "CobaltDB Connection sucessfully repaired with a propagation delay of " .. (startTime - recTime) .. "ms","CobaltDB")
+		CElog(color(32) .. "CobaltDB Connection successfully repaired with a propagation delay of " .. math.floor(recTime - startTime) .. "ms","WARN")
+		--CElog(color(32) .. "CobaltDB Connection successfully repaired with a propagation delay of " .. (startTime - recTime) .. "ms","CobaltDB")
 		CElog("/!\\ --------------------------COBALT-DB-CONNECTION-REPAIR-------------------------- /!\\","WARN")
 		return true
 	else
-		CElog("CobaltDB Connection repair was unsucessful, please try restarting your server.","WARN")
-		CElog("If you are running multiple servers, make sure each server has a unique CobaltDBport","WARN")
+		CElog("CobaltDB Connection repair was unsuccessful, please try restarting your server.","WARN")
+		CElog("If you are running multiple servers, make sure each server has a unique CobaltDBport.","WARN")
 		CElog("If the problem persists, please reach out to Cobalt Essentials support in our discord.","WARN")
 		CElog("/!\\ --------------------------COBALT-DB-CONNECTION-REPAIR-------------------------- /!\\","WARN")
 		return false

--- a/lua/CobaltDBconnector.lua
+++ b/lua/CobaltDBconnector.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --THIS SCRIPT IS PROTECTED UNDER AN GPLv3 LICENSE
 
 --    PRE: Precondition

--- a/lua/CobaltEssentials.lua
+++ b/lua/CobaltEssentials.lua
@@ -347,7 +347,7 @@ end
 
 ---------------------------------------------------------ACCESSORS---------------------------------------------------------
 
--- PRE: the sender object, command object, the arguments after the commmand as a string are passed in.
+-- PRE: the sender object, command object, the arguments after the command as a string are passed in.
 --POST: the unhandledArgs string is divided up into distinct arguments for the command.
 local function getArguments(sender, command, unhandledArgs)
 	local args = {}
@@ -474,7 +474,7 @@ local function command(sender, command, args)
 			end
 
 		else
-			CElog("Insufficent Perms")
+			CElog("Insufficient Perms")
 			return "You do not have permission to use this command."
 		end
 	else

--- a/lua/CobaltEssentials.lua
+++ b/lua/CobaltEssentials.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --COBALTESSENTIALS IS PROTECTED UNDER AN GPLv3 LICENSE
 
 --    PRE: Precondition

--- a/lua/CobaltEssentials.lua
+++ b/lua/CobaltEssentials.lua
@@ -468,9 +468,9 @@ local function command(sender, command, args)
 			end
 
 			if args == nil then
-				return _G[command.orginModule][commandName](sender)
+				return _G[command.originModule][commandName](sender)
 			else
-				return _G[command.orginModule][commandName](sender, table.unpack(args))
+				return _G[command.originModule][commandName](sender, table.unpack(args))
 			end
 
 		else

--- a/lua/CobaltExtensions.lua
+++ b/lua/CobaltExtensions.lua
@@ -152,8 +152,8 @@ end
 
 ---------------------------------------------------------ACCESSORS---------------------------------------------------------
 
--- PRE: a string 'event' is passed in, coresponding to a function in a module
---POST: any function at index event of a module is executed with parameters parameters
+-- PRE: a string 'event' is passed in, corresponding to a function in a module
+--POST: any function at index event of a module is executed with parameters
 local function triggerEvent(event, ...)
 	local args = {...}
 

--- a/lua/CobaltExtensions.lua
+++ b/lua/CobaltExtensions.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --COBALTESSENTIALS IS PROTECTED UNDER AN GPLv3 LICENSE
 
 -- PRE: Precondition

--- a/lua/CobaltPlayerMngr.lua
+++ b/lua/CobaltPlayerMngr.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --COBALTESSENTIALS IS PROTECTED UNDER AN GPLv3 LICENSE
 
 -- PRE: Precondition

--- a/lua/CobaltPlayerMngr.lua
+++ b/lua/CobaltPlayerMngr.lua
@@ -412,7 +412,7 @@ local function canSpawn(player, vehID,  data)
 
 
 			local vehicleDBobject --database object of the vehicle
-			local defaultVehiclePermissions --a boolean refering to if vehicleDBobject is of the "default" slot
+			local defaultVehiclePermissions --a boolean referring to if vehicleDBobject is of the "default" slot
 			if vehiclePermissions[data.name]:exists() then
 				vehicleDBobject = vehiclePermissions[data.name]
 				defaultVehiclePermissions = false
@@ -430,8 +430,8 @@ local function canSpawn(player, vehID,  data)
 						for slot, part2 in pairs(data.vcf.parts) do
 							if part == part2 then
 								if value > player.permissions.level then
-									CElog('Insufficent Permissions for the part: "' .. part .. "' Spawn Blocked" )
-									return false, "Insufficent permissions for the part " .. part
+									CElog('Insufficient Permissions for the part: "' .. part .. "' Spawn Blocked" )
+									return false, "Insufficient permissions for the part: " .. part
 
 								end
 								break
@@ -446,12 +446,12 @@ local function canSpawn(player, vehID,  data)
 						return false, "Vehicle Cap Reached"
 				end
 			else
-				CElog("Insufficent Permissions for this Vehicle, Spawn Blocked")
-				return false, "Insufficent permissions to spawn '" .. data.name .. "'"
+				CElog("Insufficient Permissions for this Vehicle, Spawn Blocked")
+				return false, "Insufficient permissions to spawn '" .. data.name .. "'"
 			end
 		else
-			CElog("Insufficent Permissions, Spawn Blocked")
-			return false, "Insufficent Spawn Permissions"
+			CElog("Insufficient Permissions, Spawn Blocked")
+			return false, "Insufficient Spawn Permissions"
 		end
 
 		return true

--- a/lua/CobaltUtils.lua
+++ b/lua/CobaltUtils.lua
@@ -105,7 +105,7 @@ function split(s, sep)
 end
 
 --PRE: ID is passed in, representing a player ID, an RCON ID, or C to print into console with message, a valid string.
---POST: message is output to the desired destination, if sent to players \n is seperated.
+--POST: message is output to the desired destination, if sent to players \n is separated.
 
 --IDs | "C" = console | "R<N>" = RCON | "<number>" = player
 function output(ID, message)
@@ -136,8 +136,8 @@ local function parseVehData(data)
 
 	data = data:sub(s)
 
-	local sucessful, tempData = pcall(json.parse, data)
-	if not sucessful then
+	local successful, tempData = pcall(json.parse, data)
+	if not successful then
 		--TODO: BACKUP THE JSON IN A FILE. tempData is the error, data is the json.
 		return false
 	end
@@ -151,8 +151,8 @@ local function parseVehData(data)
 
 
 	if data[4] ~= nil then
-		local sucessful, tempData = pcall(json.parse, data[4])
-		if not sucessful then
+		local successful, tempData = pcall(json.parse, data[4])
+		if not successful then
 			--TODO: BACKUP THE JSON IN A FILE. tempData is the error, data is the json.
 			return false
 		end
@@ -181,12 +181,12 @@ local function readOldCfg(path)
 			line = line:sub(1,c-1)
 		end
 
-		--see if this line even contians a value
+		--see if this line even contains a value
 		local equalSignIndex = line:find("=")
 		if equalSignIndex ~= nil then
 
 			local k = line:sub(1, equalSignIndex - 1)
-			k = k:gsub(" ", "") --remove spaces in the key, they aren't required and will serve to make thigns more confusing.
+			k = k:gsub(" ", "") --remove spaces in the key, they aren't required and will serve to make things more confusing.
 
 			local v = line:sub(equalSignIndex + 1)
 

--- a/lua/CobaltUtils.lua
+++ b/lua/CobaltUtils.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --COBALTESSENTIALS IS PROTECTED UNDER AN GPLv3 LICENSE
 
 local M = {}

--- a/lua/CobaltVehicles.lua
+++ b/lua/CobaltVehicles.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2021, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --THIS SCRIPT IS PROTECTED UNDER AN GPLv3 LICENSE
 
 --    PRE: Precondition

--- a/lua/CobaltVehicles.lua
+++ b/lua/CobaltVehicles.lua
@@ -44,8 +44,8 @@ local function parseVehData(data)
 
 	data = data:sub(s)
 
-	local sucessful, tempData = pcall(json.parse, data)
-	if not sucessful then
+	local successful, tempData = pcall(json.parse, data)
+	if not successful then
 		--TODO: BACKUP THE JSON IN A FILE. tempData is the error, data is the json.
 		return false
 	end
@@ -65,8 +65,8 @@ local function parseVehData(data)
 
 
 	if data[4] ~= nil then
-		local sucessful, tempData = pcall(json.parse, data[4])
-		if not sucessful then
+		local successful, tempData = pcall(json.parse, data[4])
+		if not successful then
 			--TODO: BACKUP THE JSON IN A FILE. tempData is the error, data is the json.
 			return false
 		end

--- a/lua/EventDBconnector.lua
+++ b/lua/EventDBconnector.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --THIS SCRIPT IS PROTECTED UNDER AN GPLv3 LICENSE
 
 --    PRE: Precondition

--- a/lua/EventDBconnector.lua
+++ b/lua/EventDBconnector.lua
@@ -113,7 +113,7 @@ local function newDatabase(DBname)
 			CElog(DBname .. " could not be opened after 5 tries due to: " .. databaseLoaderInfo:sub(3),"CobaltDB")
 			return nil, "CobaltDB failed to load " .. DBname .. "after 5 tries due to : " .. databaseLoaderInfo:sub(3)
 		else
-			CElog(DBname .. " sucessfully opened.","CobaltDB")
+			CElog(DBname .. " successfully opened.","CobaltDB")
 
 			newDatabase =
 			{
@@ -279,7 +279,7 @@ local function openDatabase(DBname)
 	local res = MP.TriggerLocalEvent("openDatabase", DBname)
 
 	if res[1] == DBname then
-		--CElog(DBname .. " sucessfully opened.","CobaltDB")
+		--CElog(DBname .. " successfully opened.","CobaltDB")
 		return true
 	else
 		return false
@@ -308,13 +308,13 @@ local function repairCobaltDBconnection(reason)
 	local recTime = os.clock() * 1000
 
 	if data == port then
-		CElog(color(32) .. "CobaltDB Connection sucessfully repaired with a propagation delay of " .. math.floor(recTime - startTime) .. "ms","WARN")
-		--CElog(color(32) .. "CobaltDB Connection sucessfully repaired with a propagation delay of " .. (startTime - recTime) .. "ms","CobaltDB")
+		CElog(color(32) .. "CobaltDB Connection successfully repaired with a propagation delay of " .. math.floor(recTime - startTime) .. "ms","WARN")
+		--CElog(color(32) .. "CobaltDB Connection successfully repaired with a propagation delay of " .. (startTime - recTime) .. "ms","CobaltDB")
 		CElog("/!\\ --------------------------COBALT-DB-CONNECTION-REPAIR-------------------------- /!\\","WARN")
 		return true
 	else
-		CElog("CobaltDB Connection repair was unsucessful, please try restarting your server.","WARN")
-		CElog("If you are running multiple servers, make sure each server has a unique CobaltDBport","WARN")
+		CElog("CobaltDB Connection repair was unsuccessful, please try restarting your server.","WARN")
+		CElog("If you are running multiple servers, make sure each server has a unique CobaltDBport.","WARN")
 		CElog("If the problem persists, please reach out to Cobalt Essentials support in our discord.","WARN")
 		CElog("/!\\ --------------------------COBALT-DB-CONNECTION-REPAIR-------------------------- /!\\","WARN")
 		return false

--- a/lua/RemoteDBconnector.lua
+++ b/lua/RemoteDBconnector.lua
@@ -1,4 +1,4 @@
---Copyright (C) 2020, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
+--Copyright (C) 2023, Preston Elam (CobaltTetra) ALL RIGHTS RESERVED
 --THIS SCRIPT IS PROTECTED UNDER AN GPLv3 LICENSE
 
 --    PRE: Precondition

--- a/lua/RemoteDBconnector.lua
+++ b/lua/RemoteDBconnector.lua
@@ -168,7 +168,7 @@ local function newDatabase(dbName, targetID)
 			CElog(dbName .. " could not be opened, Remote DB returned an invalid response: " .. dbResponseString, "WARN")
 			return nil, "Invalid response from CobaltDB"
 		else
-			CElog(dbName .. " sucessfully opened, target is: " .. parsedResposnse.targetID, "CobaltDB")
+			CElog(dbName .. " successfully opened, target is: " .. parsedResposnse.targetID, "CobaltDB")
 
 			local dbHandle =
 			{

--- a/lua/json.lua
+++ b/lua/json.lua
@@ -10,7 +10,7 @@ A Lua table is considered to be an array if and only if its set of keys is a
 consecutive sequence of positive integers starting at 1. Arrays are encoded like
 so: `[2, 3, false, "hi"]`. Any other type of Lua table is encoded as a json
 object, encoded like so: `{"key1": 2, "key2": false}`.
-Because the Lua nil value cannot be a key, and as a table value is considerd
+Because the Lua nil value cannot be a key, and as a table value is considered
 equivalent to a missing key, there is no way to express the json "null" value in
 a Lua table. The only way this will output "null" is if your entire input obj is
 nil itself.


### PR DESCRIPTION
This PR solves https://github.com/prestonelam2003/CobaltEssentials/issues/19
## Summary of changes:
* corrected typos
* formatting of log messages made more uniform
* Year in copyright / signature updated
* corrected the spelling of `orginModule`
  * replaced all occurrences with `originModule`